### PR TITLE
Add a workflow for building and pushing Docker images

### DIFF
--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       # Uses the `docker/login-action` action to log in to the Container
       # registry registry using the account and password that will

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 Alexander Dahl <post@lespocky.de>
+# SPDX-License-Identifier: CC0-1.0
+---
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the
+# branch called `release`.
+on:   # yamllint disable-line rule:truthy
+  push:
+    branches: ['release']
+
+# Defines two custom environment variables for the workflow.
+# These are used for the Container registry domain, and a name for the
+# Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow.
+# It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Uses the `docker/login-action` action to log in to the Container
+      # registry registry using the account and password that will
+      # publish the packages.
+      # Once published, the packages are scoped to the account defined here.
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # This step uses
+      # [docker/metadata-action](https://github.com/docker/metadata-action#about)
+      # to extract tags and labels that will be applied to the specified
+      # image.
+      # The `id` "meta" allows the output of this step to be referenced
+      # in a subsequent step. The `images` value provides the base name
+      # for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # This step uses the `docker/build-push-action` action to build
+      # the image, based on your repository's `Dockerfile`.
+      # If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as
+      # the set of files located in the specified path.
+      # For more information, see
+      # [Usage](https://github.com/docker/build-push-action#usage) in
+      # the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the
+      # image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which
+      # is an unforgeable statement about where and how it was built.
+      # It increases supply chain security for people who consume the image.
+      # For more information, see
+      # [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -79,11 +79,17 @@ jobs:
             # always create an image with the git sha, as fallback if none of the above applies
             type=sha
 
+      # Use the Git commit timestamp for reproducible builds
+      - name: Get Git commit timestamps
+        run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+
       # Run checks
       - name: Validate build configuration
         uses: docker/build-push-action@v6
         with:
           call: check
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       # This step uses the `docker/build-push-action` action to build
       # the image, based on your repository's `Dockerfile`.
@@ -103,6 +109,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       # This step generates an artifact attestation for the image, which
       # is an unforgeable statement about where and how it was built.

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -7,7 +7,13 @@ name: Create and publish a Docker image
 # branch called `release`.
 on:   # yamllint disable-line rule:truthy
   push:
-    branches: ['release']
+    branches:
+      - 'release'   # TODO replace with 'main' when initial development is done
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'main'
 
 # Defines two custom environment variables for the workflow.
 # These are used for the Container registry domain, and a name for the

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -8,7 +8,7 @@ name: Create and publish a Docker image
 on:   # yamllint disable-line rule:truthy
   push:
     branches:
-      - 'release'   # TODO replace with 'main' when initial development is done
+      - 'main'
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -62,6 +62,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
           tags: |
             # v1.2.3
             type=semver,pattern={{version}}

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -71,6 +71,10 @@ jobs:
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
+            # pull requests should create special tags (for testing)
+            type=ref,event=pr
+            # always create an image with the git sha, as fallback if none of the above applies
+            type=sha
 
       # This step uses the `docker/build-push-action` action to build
       # the image, based on your repository's `Dockerfile`.

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -62,6 +62,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # v1.2.3
+            type=semver,pattern={{version}}
+            # v1.2
+            type=semver,pattern={{major}}.{{minor}}
+            # v1, disabled if major zero
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
 
       # This step uses the `docker/build-push-action` action to build
       # the image, based on your repository's `Dockerfile`.

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: |
+            org.opencontainers.image.created={{commit_date 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'}}
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -14,7 +14,7 @@ on:   # yamllint disable-line rule:truthy
 # Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: apache-php
 
 # There is a single job in this workflow.
 # It's configured to run on the latest available version of Ubuntu.

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -79,6 +79,12 @@ jobs:
             # always create an image with the git sha, as fallback if none of the above applies
             type=sha
 
+      # Run checks
+      - name: Validate build configuration
+        uses: docker/build-push-action@v6
+        with:
+          call: check
+
       # This step uses the `docker/build-push-action` action to build
       # the image, based on your repository's `Dockerfile`.
       # If the build succeeds, it pushes the image to GitHub Packages.

--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -14,7 +14,7 @@ on:   # yamllint disable-line rule:truthy
 # Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: apache-php
+  IMAGE_NAME: lespocky/apache-php
 
 # There is a single job in this workflow.
 # It's configured to run on the latest available version of Ubuntu.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN a2enmod rewrite
 LABEL org.opencontainers.image.source=https://github.com/LeSpocky/docker-apache-php
 LABEL org.opencontainers.image.description="customized docker php image"
 LABEL org.opencontainers.image.licenses=MIT
-LABEL org.opencontainers.image.title=apache-php
+LABEL org.opencontainers.image.title=lespocky/apache-php

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ RUN a2enmod rewrite
 LABEL org.opencontainers.image.source=https://github.com/LeSpocky/docker-apache-php
 LABEL org.opencontainers.image.description="customized docker php image"
 LABEL org.opencontainers.image.licenses=MIT
+LABEL org.opencontainers.image.title=apache-php


### PR DESCRIPTION
GitHub should build Docker images and publish them to ghcr.io now.