### PR TITLE
ci: Introduce commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,8 +4,15 @@
 ---
 name: Check commit messages for Conventional Commits format
 
-# yamllint disable-line rule:truthy
-on: [push, pull_request]
+# Configures this workflow to run every time a change is pushed to the
+# branch called `main`, and on pull-requests to main.
+on:   # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
 
 permissions:
   contents: read

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2017 Mario Nebl
+# SPDX-FileCopyrightText: 2025 Alexander Dahl <post@lespocky.de>
+# SPDX-License-Identifier: MIT
+---
+name: Check commit messages for Conventional Commits format
+
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+      - name: Install commitlint
+        run: npm install -D @commitlint/cli @commitlint/config-conventional
+      - name: Print versions
+        run: |
+          git --version
+          node --version
+          npm --version
+          npx commitlint --version
+
+      - name: Validate current commit (last commit) with commitlint
+        if: github.event_name == 'push'
+        run: npx commitlint --last --verbose
+
+      - name: Validate PR commits with commitlint
+        if: github.event_name == 'pull_request'
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: npm
       - name: Install commitlint
         run: npm install -D @commitlint/cli @commitlint/config-conventional
       - name: Print versions

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: 2025 Alexander Dahl <post@lespocky.de>
+// SPDX-License-Identifier: CC0-1.0
+export default { extends: ['@commitlint/config-conventional'] };


### PR DESCRIPTION
After switching the commit style to conventional commits with commit 01cc46862dac56a3fbd14a301ca66e5e194dd1c8 (#12) we want to make sure all commits match the format before automatically generating things from that. 