### PR TITLE
ci(renovate): get automatic updates for semantic-release

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,18 @@
       ],
       "automerge": true
     }
+  ],
+  "regexManagers": [
+    {
+      "description": "Update semantic-release version used by npx",
+      "fileMatch": [
+        "^\\.github/workflows/[^/]+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "\\srun: npx semantic-release@(?<currentValue>.*?)\\s"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "semantic-release"
+    }
   ]
 }


### PR DESCRIPTION
As recommended by semantic-release documentation.

Link: https://semantic-release.gitbook.io/semantic-release/usage/installation#notes