### PR TITLE
fix: trigger docker image creation on release

### DIFF
--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -14,6 +14,9 @@ on:   # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - 'main'
+  release:
+    types:
+      - 'published'
 
 # Defines two custom environment variables for the workflow.
 # These are used for the Container registry domain, and a name for the


### PR DESCRIPTION
There seems to be no 'push' event from the semantic-release workflow.

Fixes: #27
Link: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release