### PR TITLE
fix(release): use fine-grained pat instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -29,5 +29,5 @@ jobs:
           node-version: "lts/*"
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         run: npx semantic-release@24


### PR DESCRIPTION
Turns out we need a different token if the release should trigger a docker image build.

Link: https://github.com/semantic-release/github?tab=readme-ov-file#github-authentication
Link: https://github.com/semantic-release/github/issues/264
Fixes: #27