### PR TITLE
ci(renovate): add "digest" to automerge update types

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,10 +9,7 @@
   "packageRules": [
     {
       "description": "Automerge non-major updates",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "matchUpdateTypes": [ "minor", "patch", "digest" ],
       "automerge": true
     },
     {


### PR DESCRIPTION
Pull request #37 was not automerged in the first try.

Link: https://docs.renovatebot.com/configuration-options/#matchupdatetypes