### PR TITLE
chore(renovate): use merge-commit for automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,9 @@
     {
       "description": "Automerge non-major updates",
       "matchUpdateTypes": [ "minor", "patch", "digest" ],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "merge-commit"
     },
     {
       "description": "set commit type for ci deps updates",


### PR DESCRIPTION
The automerge done with 0dc51ebb8bc5 ("fix(deps): update php:8.4.13-apache docker digest to 0e3cd97 (#37)") was done as fast-forward merge, which is not what the maintainer wants.

Link: https://docs.renovatebot.com/configuration-options/#automergestrategy